### PR TITLE
The formats are expected in an AudioStreamRangedDescription object

### DIFF
--- a/example/Example.cpp
+++ b/example/Example.cpp
@@ -109,6 +109,25 @@ std::shared_ptr<aspl::Driver> CreateExampleDriver()
     device->SetControlHandler(handler);
     device->SetIOHandler(handler);
 
+    //we just added a new stream so we should be safe here
+    auto ids = device->GetStreamIDs();
+    auto stream = device->GetStreamByID(ids[0]);
+    auto formats = stream->GetAvailablePhysicalFormats();
+    auto format = formats[0];
+    format.mFormat.mSampleRate = 48000;
+    format.mSampleRateRange.mMinimum = format.mSampleRateRange.mMaximum = format.mFormat.mSampleRate;
+    formats.push_back(format);
+    format.mFormat.mSampleRate = 88200;
+    format.mSampleRateRange.mMinimum = format.mSampleRateRange.mMaximum = format.mFormat.mSampleRate;
+    formats.push_back(format);
+    format.mFormat.mSampleRate = 96000;
+    format.mSampleRateRange.mMinimum = format.mSampleRateRange.mMaximum = format.mFormat.mSampleRate;
+    formats.push_back(format);
+    auto vFormats{formats};
+    stream->SetAvailablePhysicalFormatsAsync(std::move(formats));
+    stream->SetAvailableVirtualFormatsAsync(std::move(vFormats));
+    device->SetAvailableSampleRatesAsync({{44100.,44100.}, {48000.,48000.}, {88200.,88200.}, {96000.,96000.}});
+
     // Create plugin object, the root of the object hierarchy, and add
     // our device to it.
     //

--- a/include/aspl/Device.hpp
+++ b/include/aspl/Device.hpp
@@ -356,12 +356,12 @@ public:
     //!  to the maximum value.
     //! @note
     //!  Backs @c kAudioDevicePropertyAvailableNominalSampleRates property.
-    virtual std::vector<AudioValueRange> GetAvailableSampleRates() const;
+    virtual const std::vector<AudioValueRange>& GetAvailableSampleRates() const;
 
     //! Asynchrounously set list of supported nominal sample rates.
     //! See comments for GetAvailableSampleRates().
     //! Requests HAL to asynchronously invoke SetAvailableSampleRatesImpl().
-    OSStatus SetAvailableSampleRatesAsync(std::vector<AudioValueRange> rates);
+    OSStatus SetAvailableSampleRatesAsync(std::vector<AudioValueRange>&& rates);
 
     //! Return which two channels to use as left/right for stereo data by default.
     //! By default returns the last value set by SetPreferredChannelsForStereoAsync().
@@ -982,8 +982,7 @@ protected:
     //! Invoked by SetAvailableSampleRatesAsync() to actually change the list.
     //! Default implementation just updates the list returned by
     //! GetAvailableSampleRates().
-    virtual OSStatus SetAvailableSampleRatesImpl(
-        const std::vector<AudioValueRange>& rates);
+    virtual OSStatus SetAvailableSampleRatesImpl(std::vector<AudioValueRange> &&rates);
 
     //! Set channels for stereo.
     //! Invoked by SetPreferredChannelsForStereoAsync() to actually change the value.
@@ -1070,7 +1069,7 @@ private:
     // serializes writing to fields below
     mutable std::recursive_mutex writeMutex_;
 
-    DoubleBuffer<std::optional<std::vector<AudioValueRange>>> availableSampleRates_;
+    std::vector<AudioValueRange> availableSampleRates_;
     DoubleBuffer<std::array<UInt32, 2>> preferredChannelsForStereo_;
     DoubleBuffer<std::optional<UInt32>> preferredChannelCount_;
     DoubleBuffer<std::optional<std::vector<AudioChannelDescription>>> preferredChannels_;

--- a/include/aspl/Object.hpp
+++ b/include/aspl/Object.hpp
@@ -136,7 +136,7 @@ public:
     //! This is automatically called by all setters.
     void NotifyPropertyChanged(AudioObjectPropertySelector selector,
         AudioObjectPropertyScope scope = kAudioObjectPropertyScopeGlobal,
-        AudioObjectPropertyElement element = kAudioObjectPropertyElementMaster) const
+        AudioObjectPropertyElement element = kAudioObjectPropertyElementMain) const
     {
         NotifyPropertiesChanged({selector}, scope, element);
     }
@@ -146,7 +146,7 @@ public:
     void NotifyPropertiesChanged(
         const std::vector<AudioObjectPropertySelector>& selectors,
         AudioObjectPropertyScope scope = kAudioObjectPropertyScopeGlobal,
-        AudioObjectPropertyElement element = kAudioObjectPropertyElementMaster) const;
+        AudioObjectPropertyElement element = kAudioObjectPropertyElementMain) const;
 
     //! @}
 

--- a/include/aspl/Stream.hpp
+++ b/include/aspl/Stream.hpp
@@ -176,13 +176,12 @@ public:
     //! GetPhysicalFormat().
     //! @note
     //!  Backs @c kAudioStreamPropertyAvailablePhysicalFormats property.
-    virtual std::vector<AudioStreamBasicDescription> GetAvailablePhysicalFormats() const;
+    virtual const std::vector<AudioStreamRangedDescription> &GetAvailablePhysicalFormats() const;
 
     //! Asynchronously set list of supported physical formats.
     //! See comments for GetAvailablePhysicalFormats().
     //! Requests HAL to asynchronously invoke SetAvailablePhysicalFormatsImpl().
-    OSStatus SetAvailablePhysicalFormatsAsync(
-        std::vector<AudioStreamBasicDescription> formats);
+    OSStatus SetAvailablePhysicalFormatsAsync(std::vector<AudioStreamRangedDescription> &&formats);
 
     //! Get the current format of the stream.
     //! Virtual format defines the format used to present the device to the apps.
@@ -219,13 +218,13 @@ public:
     //! GetVirtualFormat().
     //! @note
     //!  Backs @c kAudioStreamPropertyAvailableVirtualFormats property.
-    virtual std::vector<AudioStreamBasicDescription> GetAvailableVirtualFormats() const;
+    virtual const std::vector<AudioStreamRangedDescription> &GetAvailableVirtualFormats() const;
 
     //! Asynchronously set list of supported virtual formats.
     //! See comments for GetAvailableVirtualFormats().
     //! Requests HAL to asynchronously invoke SetAvailableVirtualFormatsImpl().
     OSStatus SetAvailableVirtualFormatsAsync(
-        std::vector<AudioStreamBasicDescription> formats);
+        std::vector<AudioStreamRangedDescription>&& formats);
 
     //! @}
 
@@ -346,14 +345,13 @@ protected:
     //! streams have the same rate.
     //! @note
     //!  Backs @c kAudioStreamPropertyPhysicalFormat property.
-    virtual OSStatus SetPhysicalFormatImpl(const AudioStreamBasicDescription& format);
+    virtual OSStatus SetPhysicalFormatImpl(AudioStreamBasicDescription &&format);
 
     //! Set list of supported physical formats.
     //! Invoked by SetAvailablePhysicalFormatsAsync().
     //! Default implementation just changes the list returned by
     //! GetAvailablePhysicalFormats().
-    virtual OSStatus SetAvailablePhysicalFormatsImpl(
-        const std::vector<AudioStreamBasicDescription>& formats);
+    virtual OSStatus SetAvailablePhysicalFormatsImpl(std::vector<AudioStreamRangedDescription> &&formats);
 
     //! Set current virtual format of the stream.
     //! Invoked by SetVirtualFormatAsync() to actually change the format.
@@ -362,14 +360,13 @@ protected:
     //! streams have the same rate.
     //! @note
     //!  Backs @c kAudioStreamPropertyVirtualFormat property.
-    virtual OSStatus SetVirtualFormatImpl(const AudioStreamBasicDescription& format);
+    virtual OSStatus SetVirtualFormatImpl(AudioStreamBasicDescription &&format);
 
     //! Set list of supported virtual formats.
     //! Invoked by SetAvailableVirtualFormatsAsync().
     //! Default implementation just changes the list returned by
     //! GetAvailableVirtualFormats().
-    virtual OSStatus SetAvailableVirtualFormatsImpl(
-        const std::vector<AudioStreamBasicDescription>& formats);
+    virtual OSStatus SetAvailableVirtualFormatsImpl(std::vector<AudioStreamRangedDescription> &&formats);
 
     //! @}
 
@@ -391,11 +388,9 @@ private:
     DoubleBuffer<AudioStreamBasicDescription> physicalFormat_;
     DoubleBuffer<AudioStreamBasicDescription> virtualFormat_;
 
-    DoubleBuffer<std::optional<std::vector<AudioStreamBasicDescription>>>
-        availPhysicalFormats_;
+    std::vector<AudioStreamRangedDescription> availPhysicalFormats_;
 
-    DoubleBuffer<std::optional<std::vector<AudioStreamBasicDescription>>>
-        availVirtualFormats_;
+    std::vector<AudioStreamRangedDescription> availVirtualFormats_;
 
     DoubleBuffer<std::shared_ptr<VolumeControl>> volumeControl_;
     DoubleBuffer<std::shared_ptr<MuteControl>> muteControl_;

--- a/script/generate-accessors.py
+++ b/script/generate-accessors.py
@@ -138,7 +138,7 @@ OSStatus {{ class }}::Set{{ prop_name }}Async({{ prop.user_type or prop.type }} 
     }
 {% endif %}
 
-    RequestConfigurationChange([this, value]() {
+    RequestConfigurationChange([this, value = std::move(value)]()mutable {
         std::lock_guard<decltype({{ setter_mutex }})> writeLock({{ setter_mutex }});
 
         Tracer::Operation op;
@@ -155,7 +155,7 @@ OSStatus {{ class }}::Set{{ prop_name }}Async({{ prop.user_type or prop.type }} 
             GetContext()->Tracer->Message("setting value to %s",
                 Convert::ToString(value).c_str());
 
-            status = Set{{ prop_name }}Impl(value);
+            status = Set{{ prop_name }}Impl(std::move(value));
         }
 
         GetContext()->Tracer->OperationEnd(op, status);

--- a/src/Compare.hpp
+++ b/src/Compare.hpp
@@ -44,3 +44,15 @@ inline bool operator!=(const AudioStreamBasicDescription& a,
 {
     return !(a == b);
 }
+
+inline bool operator==(const AudioStreamRangedDescription& a,
+	const AudioStreamRangedDescription& b)
+{
+	return a.mFormat == b.mFormat && a.mSampleRateRange == b.mSampleRateRange;
+}
+
+inline bool operator!=(const AudioStreamRangedDescription& a,
+	const AudioStreamRangedDescription& b)
+{
+	return !(a == b);
+}

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -182,10 +182,10 @@ OSStatus Device::SetSampleRateImpl(Float64 rate)
     return status;
 }
 
-std::vector<AudioValueRange> Device::GetAvailableSampleRates() const
+const std::vector<AudioValueRange> &Device::GetAvailableSampleRates() const
 {
-    if (auto rates = availableSampleRates_.Get()) {
-        return *rates;
+    if (availableSampleRates_.size()) {
+        return availableSampleRates_;
     }
 
     const auto sampleRate = GetSampleRate();
@@ -197,9 +197,9 @@ std::vector<AudioValueRange> Device::GetAvailableSampleRates() const
     return {range};
 }
 
-OSStatus Device::SetAvailableSampleRatesImpl(const std::vector<AudioValueRange>& rates)
+OSStatus Device::SetAvailableSampleRatesImpl(std::vector<AudioValueRange>&& rates)
 {
-    availableSampleRates_.Set(rates);
+    std::swap(availableSampleRates_, rates);
 
     return kAudioHardwareNoError;
 }

--- a/src/Device.g.cpp
+++ b/src/Device.g.cpp
@@ -2,7 +2,7 @@
 
 // Generator: generate-accessors.py
 // Source: Device.json
-// Timestamp: Thu Feb 03 11:44:38 2022 UTC
+// Timestamp: Thu Jun 23 19:46:33 2022 UTC
 
 // Copyright (c) libASPL authors
 // Licensed under MIT
@@ -55,7 +55,7 @@ OSStatus Device::SetLatencyAsync(UInt32 value)
         goto end;
     }
 
-    RequestConfigurationChange([this, value]() {
+    RequestConfigurationChange([this, &value]() {
         std::lock_guard<decltype(writeMutex_)> writeLock(writeMutex_);
 
         Tracer::Operation op;
@@ -72,7 +72,7 @@ OSStatus Device::SetLatencyAsync(UInt32 value)
             GetContext()->Tracer->Message("setting value to %s",
                 Convert::ToString(value).c_str());
 
-            status = SetLatencyImpl(value);
+            status = SetLatencyImpl(std::move(value));
         }
 
         GetContext()->Tracer->OperationEnd(op, status);
@@ -101,7 +101,7 @@ OSStatus Device::SetSafetyOffsetAsync(UInt32 value)
         goto end;
     }
 
-    RequestConfigurationChange([this, value]() {
+    RequestConfigurationChange([this, &value]() {
         std::lock_guard<decltype(writeMutex_)> writeLock(writeMutex_);
 
         Tracer::Operation op;
@@ -118,7 +118,7 @@ OSStatus Device::SetSafetyOffsetAsync(UInt32 value)
             GetContext()->Tracer->Message("setting value to %s",
                 Convert::ToString(value).c_str());
 
-            status = SetSafetyOffsetImpl(value);
+            status = SetSafetyOffsetImpl(std::move(value));
         }
 
         GetContext()->Tracer->OperationEnd(op, status);
@@ -147,7 +147,7 @@ OSStatus Device::SetZeroTimeStampPeriodAsync(UInt32 value)
         goto end;
     }
 
-    RequestConfigurationChange([this, value]() {
+    RequestConfigurationChange([this, &value]() {
         std::lock_guard<decltype(writeMutex_)> writeLock(writeMutex_);
 
         Tracer::Operation op;
@@ -164,7 +164,7 @@ OSStatus Device::SetZeroTimeStampPeriodAsync(UInt32 value)
             GetContext()->Tracer->Message("setting value to %s",
                 Convert::ToString(value).c_str());
 
-            status = SetZeroTimeStampPeriodImpl(value);
+            status = SetZeroTimeStampPeriodImpl(std::move(value));
         }
 
         GetContext()->Tracer->OperationEnd(op, status);
@@ -199,7 +199,7 @@ OSStatus Device::SetSampleRateAsync(Float64 value)
         goto end;
     }
 
-    RequestConfigurationChange([this, value]() {
+    RequestConfigurationChange([this, &value]() {
         std::lock_guard<decltype(writeMutex_)> writeLock(writeMutex_);
 
         Tracer::Operation op;
@@ -216,7 +216,7 @@ OSStatus Device::SetSampleRateAsync(Float64 value)
             GetContext()->Tracer->Message("setting value to %s",
                 Convert::ToString(value).c_str());
 
-            status = SetSampleRateImpl(value);
+            status = SetSampleRateImpl(std::move(value));
         }
 
         GetContext()->Tracer->OperationEnd(op, status);
@@ -228,7 +228,7 @@ end:
     return status;
 }
 
-OSStatus Device::SetAvailableSampleRatesAsync(std::vector<AudioValueRange> value)
+OSStatus Device::SetAvailableSampleRatesAsync(std::vector<AudioValueRange>&& value)
 {
     std::lock_guard<decltype(writeMutex_)> writeLock(writeMutex_);
 
@@ -245,7 +245,7 @@ OSStatus Device::SetAvailableSampleRatesAsync(std::vector<AudioValueRange> value
         goto end;
     }
 
-    RequestConfigurationChange([this, value]() {
+    RequestConfigurationChange([this, &value]() {
         std::lock_guard<decltype(writeMutex_)> writeLock(writeMutex_);
 
         Tracer::Operation op;
@@ -262,7 +262,7 @@ OSStatus Device::SetAvailableSampleRatesAsync(std::vector<AudioValueRange> value
             GetContext()->Tracer->Message("setting value to %s",
                 Convert::ToString(value).c_str());
 
-            status = SetAvailableSampleRatesImpl(value);
+            status = SetAvailableSampleRatesImpl(std::move(value));
         }
 
         GetContext()->Tracer->OperationEnd(op, status);
@@ -291,7 +291,7 @@ OSStatus Device::SetPreferredChannelsForStereoAsync(std::array<UInt32, 2> value)
         goto end;
     }
 
-    RequestConfigurationChange([this, value]() {
+    RequestConfigurationChange([this, &value]() {
         std::lock_guard<decltype(writeMutex_)> writeLock(writeMutex_);
 
         Tracer::Operation op;
@@ -308,7 +308,7 @@ OSStatus Device::SetPreferredChannelsForStereoAsync(std::array<UInt32, 2> value)
             GetContext()->Tracer->Message("setting value to %s",
                 Convert::ToString(value).c_str());
 
-            status = SetPreferredChannelsForStereoImpl(value);
+            status = SetPreferredChannelsForStereoImpl(std::move(value));
         }
 
         GetContext()->Tracer->OperationEnd(op, status);
@@ -337,7 +337,7 @@ OSStatus Device::SetPreferredChannelCountAsync(UInt32 value)
         goto end;
     }
 
-    RequestConfigurationChange([this, value]() {
+    RequestConfigurationChange([this, &value]() {
         std::lock_guard<decltype(writeMutex_)> writeLock(writeMutex_);
 
         Tracer::Operation op;
@@ -354,7 +354,7 @@ OSStatus Device::SetPreferredChannelCountAsync(UInt32 value)
             GetContext()->Tracer->Message("setting value to %s",
                 Convert::ToString(value).c_str());
 
-            status = SetPreferredChannelCountImpl(value);
+            status = SetPreferredChannelCountImpl(std::move(value));
         }
 
         GetContext()->Tracer->OperationEnd(op, status);
@@ -383,7 +383,7 @@ OSStatus Device::SetPreferredChannelsAsync(std::vector<AudioChannelDescription> 
         goto end;
     }
 
-    RequestConfigurationChange([this, value]() {
+    RequestConfigurationChange([this, &value]() {
         std::lock_guard<decltype(writeMutex_)> writeLock(writeMutex_);
 
         Tracer::Operation op;
@@ -400,7 +400,7 @@ OSStatus Device::SetPreferredChannelsAsync(std::vector<AudioChannelDescription> 
             GetContext()->Tracer->Message("setting value to %s",
                 Convert::ToString(value).c_str());
 
-            status = SetPreferredChannelsImpl(value);
+            status = SetPreferredChannelsImpl(std::move(value));
         }
 
         GetContext()->Tracer->OperationEnd(op, status);
@@ -429,7 +429,7 @@ OSStatus Device::SetPreferredChannelLayoutAsync(std::vector<UInt8> value)
         goto end;
     }
 
-    RequestConfigurationChange([this, value]() {
+    RequestConfigurationChange([this, &value]() {
         std::lock_guard<decltype(writeMutex_)> writeLock(writeMutex_);
 
         Tracer::Operation op;
@@ -446,7 +446,7 @@ OSStatus Device::SetPreferredChannelLayoutAsync(std::vector<UInt8> value)
             GetContext()->Tracer->Message("setting value to %s",
                 Convert::ToString(value).c_str());
 
-            status = SetPreferredChannelLayoutImpl(value);
+            status = SetPreferredChannelLayoutImpl(std::move(value));
         }
 
         GetContext()->Tracer->OperationEnd(op, status);

--- a/src/Device.json
+++ b/src/Device.json
@@ -96,7 +96,7 @@
         "AvailableSampleRates": {
             "id": "kAudioDevicePropertyAvailableNominalSampleRates",
             "type": "AudioValueRange",
-            "user_type": "std::vector<AudioValueRange>",
+            "user_type": "std::vector<AudioValueRange>&&",
             "is_array": true,
             "is_user_settable": true,
             "is_async": true

--- a/src/MuteControl.g.cpp
+++ b/src/MuteControl.g.cpp
@@ -2,7 +2,7 @@
 
 // Generator: generate-accessors.py
 // Source: MuteControl.json
-// Timestamp: Thu Feb 03 11:44:38 2022 UTC
+// Timestamp: Sat Jun 25 05:12:44 2022 UTC
 
 // Copyright (c) libASPL authors
 // Licensed under MIT

--- a/src/Object.g.cpp
+++ b/src/Object.g.cpp
@@ -2,7 +2,7 @@
 
 // Generator: generate-accessors.py
 // Source: Object.json
-// Timestamp: Thu Feb 03 11:44:38 2022 UTC
+// Timestamp: Sat Jun 25 05:12:44 2022 UTC
 
 // Copyright (c) libASPL authors
 // Licensed under MIT

--- a/src/Plugin.g.cpp
+++ b/src/Plugin.g.cpp
@@ -2,7 +2,7 @@
 
 // Generator: generate-accessors.py
 // Source: Plugin.json
-// Timestamp: Thu Feb 03 11:44:38 2022 UTC
+// Timestamp: Sat Jun 25 05:12:44 2022 UTC
 
 // Copyright (c) libASPL authors
 // Licensed under MIT

--- a/src/Stream.json
+++ b/src/Stream.json
@@ -47,16 +47,16 @@
         },
         "AvailablePhysicalFormats": {
             "id": "kAudioStreamPropertyAvailablePhysicalFormats",
-            "type": "AudioStreamBasicDescription",
-            "user_type": "std::vector<AudioStreamBasicDescription>",
+            "type": "AudioStreamRangedDescription",
+            "user_type": "std::vector<AudioStreamRangedDescription>&&",
             "is_array": true,
             "is_user_settable": true,
             "is_async": true
         },
         "AvailableVirtualFormats": {
             "id": "kAudioStreamPropertyAvailableVirtualFormats",
-            "type": "AudioStreamBasicDescription",
-            "user_type": "std::vector<AudioStreamBasicDescription>",
+            "type": "AudioStreamRangedDescription",
+            "user_type": "std::vector<AudioStreamRangedDescription>&&",
             "is_array": true,
             "is_user_settable": true,
             "is_async": true

--- a/src/VolumeControl.g.cpp
+++ b/src/VolumeControl.g.cpp
@@ -2,7 +2,7 @@
 
 // Generator: generate-accessors.py
 // Source: VolumeControl.json
-// Timestamp: Thu Feb 03 11:44:38 2022 UTC
+// Timestamp: Sat Jun 25 05:12:44 2022 UTC
 
 // Copyright (c) libASPL authors
 // Licensed under MIT


### PR DESCRIPTION
Fill available formats vectors with default format on startup
Changed containers to plain STL ones, since they are only populated on startup.