### PR TITLE
Fixed an issue with basing ZeroTimeStampPeriod off sample rate

### DIFF
--- a/include/aspl/Device.hpp
+++ b/include/aspl/Device.hpp
@@ -1223,6 +1223,7 @@ private:
     std::atomic<UInt32> latency_;
     std::atomic<UInt32> safetyOffset_;
     std::atomic<UInt32> zeroTimeStampPeriod_;
+    const bool zeroTimeStampPeriodBasedOffSampleRate_;
     std::atomic<Float64> nominalSampleRate_;
 
     std::atomic<SInt32> startCount_ = 0;

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -26,6 +26,7 @@ Device::Device(std::shared_ptr<const Context> context, const DeviceParameters& p
     , safetyOffset_(params.SafetyOffset)
     , zeroTimeStampPeriod_(
           params_.ZeroTimeStampPeriod ? params_.ZeroTimeStampPeriod : params_.SampleRate)
+    , zeroTimeStampPeriodBasedOffSampleRate_(!params_.ZeroTimeStampPeriod)
     , nominalSampleRate_(params.SampleRate)
     , preferredChannelsForStereo_({1, 2})
 {
@@ -161,6 +162,11 @@ OSStatus Device::CheckNominalSampleRate(Float64 rate) const
 OSStatus Device::SetNominalSampleRateImpl(Float64 rate)
 {
     nominalSampleRate_ = rate;
+
+    if(zeroTimeStampPeriodBasedOffSampleRate_)
+    {
+        SetZeroTimeStampPeriodImpl(rate);
+    }
 
     return kAudioHardwareNoError;
 }


### PR DESCRIPTION
If zero timestamp period is initially set based on sample rate, then sample rate changes this causes zero timestamp period to be out of sync. This fix resets zero timestamp period when sample rate changes if it is originally based upon sample rate.